### PR TITLE
The default-serif example was $default-sans-serif, corrected

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -72,7 +72,7 @@ Then you can simply pass "sans-serif" to the `font-family()` function or mixin t
 
 By default, `$default-serif` is set to "Georgia".
 
-    $default-sans-serif: "Georgia"
+    $default-serif: "Georgia"
     
 You can set this variable to another available font, such as "Times". Here's an example:
 


### PR DESCRIPTION
My first pull request, let me know if I did anything wrong and be easy on me :).
